### PR TITLE
implement coordinate-type obs_space and concat obs_space

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -131,6 +131,9 @@ dmypy.json
 .idea/
 .DS_Store
 
+credentials.py
+
 training_pipeline/models/
 training_pipeline/runs/
 training_pipeline/wandb/
+training_pipeline/videos/

--- a/gym_env/envs/dino_wrapper.py
+++ b/gym_env/envs/dino_wrapper.py
@@ -1,0 +1,27 @@
+from collections import deque
+import gym
+from gym import spaces
+import numpy as np
+
+class ConcatObs(gym.Wrapper):
+    def __init__(self, env, k):
+        gym.Wrapper.__init__(self, env)
+        self.k = k
+        self.concat_obs = deque([], maxlen=k)
+        shp = env.observation_space.shape
+        self.observation_space = spaces.Box(low=-np.inf, high=np.inf, shape=((k,) + shp), dtype=env.observation_space.dtype)
+        print('Wrapping the env in ConcatObs with 6-lookback observation_space')
+
+    def reset(self):
+        ob = self.env.reset()
+        for _ in range(self.k):
+            self.concat_obs.append(ob)
+        return self._get_ob()
+
+    def step(self, action):
+        ob, reward, done, info = self.env.step(action)
+        self.concat_obs.append(ob)
+        return self._get_ob(), reward, done, info
+
+    def _get_ob(self):
+        return np.array(self.concat_obs)

--- a/gym_env/spaces/items.py
+++ b/gym_env/spaces/items.py
@@ -41,6 +41,7 @@ class RockItem(Point):
     def __init__(self, name, icon_idx, x_min, x_max, y_min, y_max):
         super(RockItem, self).__init__(name, x_min, x_max, y_min, y_max)
 
+        self.icon_idx = icon_idx
         icon_name = self.icon_names[icon_idx]
         self.icon_image = self.icon_info[icon_name]['image']
         self.icon_width = self.icon_info[icon_name]['width']

--- a/training_pipeline/demo_pipeline.py
+++ b/training_pipeline/demo_pipeline.py
@@ -8,6 +8,7 @@ from gym.utils import seeding
 
 from gym_env.spaces.person import Person
 from gym_env.spaces.items import RockItem, BirdItem, EnergyItem
+from gym_env.envs.dino_wrapper import ConcatObs
 
 import argparse
 import pendulum
@@ -28,13 +29,14 @@ def make_env(env_id, seed):
     env = gym.make(env_id)
     env.seed(seed)
     # check_env(_env)
+    env = ConcatObs(env, 6)
     env = Monitor(env)
     print('successfully create gym environment')
     return env
 
 config = {
         "algorithm": "DQN",
-        "policy_type": "CnnPolicy",
+        "policy_type": "MlpPolicy",
         "seed": 0
     }
 
@@ -53,7 +55,7 @@ for i in range(5):
     while True:
         action = model.action_space.sample()
         obs, reward, done, info = env.step(action)
-        # env.render()
+        env.render()
         time.sleep(0.1)
         if done:
             break

--- a/training_pipeline/model_evaluation.py
+++ b/training_pipeline/model_evaluation.py
@@ -1,0 +1,36 @@
+import gym
+from stable_baselines3 import PPO, DQN
+from stable_baselines3.common.monitor import Monitor
+import time
+
+import gym_env  # import this directory to create environment
+
+
+def make_env(env_id, seed):
+    env = gym.make(env_id)
+    env.seed(seed)
+    # check_env(_env)
+    env = Monitor(env)
+    print('successfully create gym environment')
+    return env
+
+
+model_path = '/Users/thakorns/Desktop/Eyp/codebases/rl-dino-gym/training_pipeline/models/2ff55tdz/model.zip'
+model = DQN.load(path=model_path, device='cpu')
+
+env = make_env(env_id='DinoGame-v0', seed=0)
+
+for i in range(5):
+    obs = env.reset()
+    ep_reward = 0
+    while True:
+        _action = model.predict(obs, deterministic=True)
+        action = _action[0].item()
+        env.render()
+        obs, reward, done, info = env.step(action)
+        ep_reward += reward
+        time.sleep(0.1)
+
+        if done:
+            print(f'trial-{i}: reward={ep_reward}, info={info}\n')
+            break

--- a/training_pipeline/run_training.py
+++ b/training_pipeline/run_training.py
@@ -10,13 +10,14 @@ import wandb
 from wandb.integration.sb3 import WandbCallback
 
 import gym_env  # import this directory to create environment
+from gym_env.envs.dino_wrapper import ConcatObs
 
 
 def pipeline_arg_parser():
     parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
     parser.add_argument('--env-id', '-e', help='environment ID', type=str, default='DinoGame-v0')
     parser.add_argument('--seed', '-s', help='reproduce seed', type=int, default=0)
-    parser.add_argument('--num-timesteps', type=int, default=int(5e5))
+    parser.add_argument('--num-timesteps', type=int, default=int(2.5e6))
     return parser.parse_args()
 
 
@@ -42,6 +43,7 @@ def make_env(env_id, seed):
         _env = gym.make(env_id)
         _env.seed(seed)
         # check_env(_env)
+        _env = ConcatObs(_env, 6)
         _env = Monitor(_env)
         return _env
     env = DummyVecEnv([_make_env])
@@ -81,8 +83,10 @@ if __name__ == '__main__':
 
     config_info = {
         "algorithm": "DQN",
-        "policy_type": "CnnPolicy",
-        "seed": working_seed
+        "policy_type": "MlpPolicy",
+        "seed": working_seed,
+        "reward_conditions": "step: +1, energy spawn: 20%, energy: +20, bird/rock/done: -30, miss energy: -20, miss rock/bird: +5",
+        "concat obs": "6-lookback observation_space"
     }
 
     env = make_env(env_id, working_seed)


### PR DESCRIPTION
**Task 1: coordinate-type obs_space** 
* implement the coordinate-type obs_space to use instead of image-type obs_space
* the obs_space will be list of information of all items included in the canvas frame
* we can be able to apply `MlpPolicy` instead of `CnnPolicy` policy when training

**Task 2: concat obs_space**
* create a new obs_space which will concat multiple obs_space
* this implementation will allow the model to be able to look-back X steps in each predictions

**Other updates**
* `dino_eny.py`: integrate video generation feature
* `dino_eny.py`: change reward function design to receive more reward after passing/collecting each item
* `model_evaluation.py`: allow to demo the model prediction result as a gameplay-video